### PR TITLE
DOCOPS-176 Add page-tabs attributes to publish playbook

### DIFF
--- a/publish.yml
+++ b/publish.yml
@@ -34,6 +34,8 @@ asciidoc:
   - "@neo4j-documentation/macros"
   - "@neo4j-antora/mark-terms"
   attributes:
+    page-tabs: administration@
+    page-tabs-index: 40
     # page-attributes are used by the ui-bundle and by extensions
     page-theme: docs
     page-type: Docs


### PR DESCRIPTION
Adds `page-tabs` and `page-tabs-index` to `publish.yml`:

```yaml
page-tabs: administration@
page-tabs-index: 40
```

Places this docset in the `administration` tab of the aggregated tabbed navigation, at the
position matching its order in the Docs menu on neo4j.com/docs. The value is
soft-set with a trailing `@` so it can be overridden in `antora.yml` or on a page.
